### PR TITLE
replace base and udev hooks with systemd in mkinitcpio

### DIFF
--- a/archiso/airootfs/etc/mkinitcpio.conf
+++ b/archiso/airootfs/etc/mkinitcpio.conf
@@ -49,7 +49,7 @@ FILES=()
 #
 ##   NOTE: If you have /usr on a separate partition, you MUST include the
 #    usr, fsck and shutdown hooks.
-HOOKS=(base udev modconf memdisk archiso archiso_loop_mnt archiso_pxe_common archiso_pxe_nbd archiso_pxe_http archiso_pxe_nfs archiso_kms block filesystems keyboard)
+HOOKS=(systemd modconf memdisk archiso archiso_loop_mnt archiso_pxe_common archiso_pxe_nbd archiso_pxe_http archiso_pxe_nfs archiso_kms block filesystems keyboard) # systemd replaces base and udev
 
 # COMPRESSION
 # Use this to compress the initramfs image. By default, gzip compression


### PR DESCRIPTION
for reference: https://wiki.archlinux.org/title/Improving_performance/Boot_process#Using_systemd_instead_of_busybox_on_early_init